### PR TITLE
Updated POM.xml with Source version and Cobertura support

### DIFF
--- a/MavenProject/pom.xml
+++ b/MavenProject/pom.xml
@@ -40,10 +40,13 @@
                     <version>2.4</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
-                </plugin>
+		    <groupId>org.apache.maven.plugins</groupId>
+		    <artifactId>maven-compiler-plugin</artifactId>
+		    <configuration>
+			<source>1.6</source>
+			<target>1.6</target>
+		    </configuration>
+		</plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -74,6 +77,16 @@
            		<format>xml</format>
        		    </formats>
     		</configuration>
+	    </plugin>
+	    <plugin>
+		    <groupId>org.codehaus.mojo</groupId>
+		    <artifactId>cobertura-maven-plugin</artifactId>
+		    <configuration>
+			    <formats>
+				    <format>html</format>
+				    <format>xml</format>
+			    </formats>
+		    </configuration>
 	    </plugin>
 	    <plugin>
     		<groupId>org.apache.tomcat.maven</groupId>


### PR DESCRIPTION
ERROR Source option 1.5 is no longer supported. Use 1.6 or later
Added maven library for Cobertura support